### PR TITLE
Always call next() on both tokenizers, to make sure both r1 and r2 files are read to the end

### DIFF
--- a/src/lib/workflow/DualFastq2SamWorkflow.cpp
+++ b/src/lib/workflow/DualFastq2SamWorkflow.cpp
@@ -96,7 +96,14 @@ void DualFastq2SamWorkflow::alignDualFastq(
   align::Aligner::ReadPair   pair;
 
   int64_t fragmentId = 0;
-  while (r1Tokenizer.next() && r2Tokenizer.next()) {
+  while (true) {
+    // Always call next() on both tokenizers, to make sure both files are read to the end.
+    const bool r1Next = r1Tokenizer.next();
+    const bool r2Next = r2Tokenizer.next();
+    if (!r1Next || !r2Next) {
+      break;
+    }
+
     const auto& r1Token = r1Tokenizer.token();
     const auto& r2Token = r2Tokenizer.token();
     //    std::cout << "token: " << r1Token << "-" << r2Token << "\n";

--- a/src/lib/workflow/DualFastq2SamWorkflow.cpp
+++ b/src/lib/workflow/DualFastq2SamWorkflow.cpp
@@ -45,7 +45,14 @@ align::InsertSizeParameters DualFastq2SamWorkflow::requestInsertSizeInfo(
 
   align::InsertSizeParameters ret;
   bool                        retDone = false;
-  while (r1Tokenizer.next() && r2Tokenizer.next()) {
+  while (true) {
+    // Always call next() on both tokenizers, to make sure both files are read to the end.
+    const bool r1Next = r1Tokenizer.next();
+    const bool r2Next = r2Tokenizer.next();
+    if (!r1Next || !r2Next) {
+      break;
+    }
+
     const auto& r1Token = r1Tokenizer.token();
     const auto& r2Token = r2Tokenizer.token();
     //    std::cout << "token: " << r1Token << "-" << r2Token << "\n";


### PR DESCRIPTION
Fixes https://github.com/Illumina/DRAGMAP/issues/41.